### PR TITLE
WebSocket.connect/2 returns process name

### DIFF
--- a/lib/absinthe_client.ex
+++ b/lib/absinthe_client.ex
@@ -147,11 +147,10 @@ defmodule AbsintheClient do
 
   Performing a `subscription` operation:
 
-      iex> req =
-      ...>   Req.new(base_url: "http://localhost:8001")
-      ...>   |> AbsintheClient.attach()
-      ...>   |> AbsintheClient.WebSocket.connect!()
+      iex> req = Req.new(base_url: "http://localhost:8001") |> AbsintheClient.attach()
+      iex> ws = req |> AbsintheClient.WebSocket.connect!()
       iex> Req.request!(req,
+      ...>   web_socket: ws,
       ...>   graphql: {
       ...>     \"""
       ...>     subscription ($repository: Repository!) {
@@ -168,11 +167,10 @@ defmodule AbsintheClient do
 
   Performing an asynchronous `subscription` operation and awaiting the reply:
 
-      iex> req =
-      ...>   Req.new(base_url: "http://localhost:8001")
-      ...>   |> AbsintheClient.attach()
-      ...>   |> AbsintheClient.WebSocket.connect!()
+      iex> req = Req.new(base_url: "http://localhost:8001") |> AbsintheClient.attach()
+      iex> ws = req |> AbsintheClient.WebSocket.connect!()
       iex> res = Req.request!(req,
+      ...>   web_socket: ws,
       ...>   async: true,
       ...>   graphql: {
       ...>     \"""
@@ -191,11 +189,10 @@ defmodule AbsintheClient do
 
   Authorization via the request `:auth` option:
 
-      iex> req =
-      ...>   Req.new(base_url: "http://localhost:8001/", auth: {:bearer, "valid-token"})
-      ...>   |> AbsintheClient.attach()
-      ...>   |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
+      iex> req = Req.new(base_url: "http://localhost:8001/", auth: {:bearer, "valid-token"}) |> AbsintheClient.attach()
+      iex> ws = req |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
       iex> res = Req.request!(req,
+      ...>   web_socket: ws,
       ...>   async: true,
       ...>   graphql: {
       ...>     \"""
@@ -217,8 +214,9 @@ defmodule AbsintheClient do
       iex> req =
       ...>   Req.new(base_url: "http://localhost:8001/")
       ...>   |> AbsintheClient.attach(connect_params: %{"token" => "valid-token"})
-      ...>   |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
+      iex> ws = req |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
       iex> res = Req.request!(req,
+      ...>   web_socket: ws,
       ...>   async: true,
       ...>   graphql: {
       ...>     \"""
@@ -240,8 +238,9 @@ defmodule AbsintheClient do
       iex> req =
       ...>   Req.new(base_url: "http://localhost:8001/", auth: {:bearer, "invalid-token"})
       ...>   |> AbsintheClient.attach(retry: :never)
-      ...>   |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
+      iex> ws = req |> AbsintheClient.WebSocket.connect!(url: "/auth-socket/websocket")
       iex> res = Req.request!(req,
+      ...>   web_socket: ws,
       ...>   async: true,
       ...>   graphql: {
       ...>     \"""

--- a/test/absinthe_client/integration/subscriptions_test.exs
+++ b/test/absinthe_client/integration/subscriptions_test.exs
@@ -7,8 +7,7 @@ defmodule AbsintheClient.Integration.SubscriptionsTest do
     def start_link(arg), do: GenServer.start_link(__MODULE__, arg)
 
     def init({client, parent}) do
-      client = AbsintheClient.WebSocket.connect!(client)
-      socket_name = client.options.web_socket
+      socket_name = AbsintheClient.WebSocket.connect!(client)
 
       {:ok, %{parent: parent, client: client, socket: socket_name}}
     end
@@ -32,6 +31,7 @@ defmodule AbsintheClient.Integration.SubscriptionsTest do
       subscription =
         Req.request!(
           state.client,
+          web_socket: state.socket,
           graphql: {
             """
             subscription RepoCommentSubscription($repository: Repository!){


### PR DESCRIPTION
Closes #9 

Returning a Request struct with the web_socket option already set by WebSocket.connect/2 made it difficult to re-use the same Request for HTTP and WebSocket connections. This requires carrying around two Request structs in the base case (the reference app) so instead with this change we can carry around the Request and the socket name and only apply it to operations that need the WebSocket (i.e subscriptions).